### PR TITLE
fix width of title label to respect padding and image

### DIFF
--- a/LNRSimpleNotifications/Classes/LNRSimpleNotificationView.swift
+++ b/LNRSimpleNotifications/Classes/LNRSimpleNotificationView.swift
@@ -161,7 +161,7 @@ public class LNRSimpleNotificationView: UIView, UIGestureRecognizerDelegate {
             textLabelsXPosition += image.size.width
         }
         
-        self.titleLabel.frame = CGRect(x: textLabelsXPosition, y: topPadding, width: notificationWidth, height: CGFloat(0.0))
+        self.titleLabel.frame = CGRect(x: textLabelsXPosition, y: topPadding, width: notificationWidth - textLabelsXPosition - padding, height: CGFloat(0.0))
         self.titleLabel.sizeToFit()
         
         if self.body != nil && (self.body!).characters.count > 0 {


### PR DESCRIPTION
The width of the `titleLabel` was set to the whole `notificationWidth`, not respecting the padding and not respecting the presence of an image. 

This lead to the following Bug:

![screen shot 2015-11-19 at 14 06 27 2](https://cloud.githubusercontent.com/assets/3407787/11271802/d1fbf864-8ec8-11e5-9dd1-deadb7d33251.png)
![screen shot 2015-11-19 at 14 06 51 2](https://cloud.githubusercontent.com/assets/3407787/11271804/d2202f9a-8ec8-11e5-8fbf-dba29e5791a2.png)

### Fixed

With this fix these now look like that:

![screen shot 2015-11-19 at 14 16 17 2](https://cloud.githubusercontent.com/assets/3407787/11271847/0d0eebbe-8ec9-11e5-825f-84d8cbda3a9f.png)
![screen shot 2015-11-19 at 14 17 12 2](https://cloud.githubusercontent.com/assets/3407787/11271848/0d31c878-8ec9-11e5-9fd3-6b8fe1e4e323.png)


### Autolayout

Btw, would it not be better to use Autolayout? 
