### PR TITLE
Update the width to use the width of the window instead of the screen.

### DIFF
--- a/LNRSimpleNotifications/Classes/LNRNotificationView.swift
+++ b/LNRSimpleNotifications/Classes/LNRNotificationView.swift
@@ -65,7 +65,7 @@ public class LNRNotificationView: UIView, UIGestureRecognizerDelegate {
             self.onTap = onTap
         }
         
-        let notificationWidth: CGFloat = UIScreen.mainScreen().bounds.size.width
+        let notificationWidth: CGFloat = (UIApplication.sharedApplication().keyWindow?.bounds.width)!
         let padding: CGFloat = kLNRNotificationViewMinimumPadding
         
         super.init(frame: CGRect.zero)
@@ -148,7 +148,7 @@ public class LNRNotificationView: UIView, UIGestureRecognizerDelegate {
     
     override public func layoutSubviews() {
         super.layoutSubviews()
-        self.notificationViewHeightAfterLayoutOutSubviews(kLNRNotificationViewMinimumPadding, notificationWidth: UIScreen.mainScreen().bounds.size.width)
+        self.notificationViewHeightAfterLayoutOutSubviews(kLNRNotificationViewMinimumPadding, notificationWidth: (UIApplication.sharedApplication().keyWindow?.bounds.width)!)
     }
     
     func notificationViewHeightAfterLayoutOutSubviews(padding: CGFloat, notificationWidth: CGFloat) -> CGFloat {


### PR DESCRIPTION
When an app is in multitasking mode (on iPad), the width of the notification extends beyond the width of the window.

This happens on iPad when apps are in side-by-side mode.

I changed these lines in LNRNotificationView

```
let notificationWidth: CGFloat = (UIApplication.sharedApplication().keyWindow?.bounds.width)!
```
```
override public func layoutSubviews() {
        super.layoutSubviews()
        self.notificationViewHeightAfterLayoutOutSubviews(kLNRNotificationViewMinimumPadding, notificationWidth: (UIApplication.sharedApplication().keyWindow?.bounds.width)!)
    }
```
