### PR TITLE
Solved warnings related to deprecated String properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.1
+- Solved warnings related to deprecated String properties
+
 ## 0.7.0
 ### Changed
 - Updated for Swift 4.

--- a/LNRSimpleNotifications.podspec
+++ b/LNRSimpleNotifications.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "LNRSimpleNotifications"
-  s.version          = "0.7.0"
+  s.version          = "0.7.1"
   s.summary          = "Simple Swift in-app notifications."
   s.description      = <<-DESC
                        LNRSimpleNotifications is a simplified Swift port of TSMessages. It's built for developers who want beautiful in-app notifications that can be set up in minutes.

--- a/Source/LNRNotificationView.swift
+++ b/Source/LNRNotificationView.swift
@@ -53,7 +53,7 @@ public class LNRNotificationView: UIView, UIGestureRecognizerDelegate {
         self.addSubview(self.titleLabel)
         
         if let bodyText = notification.body {
-            if bodyText.characters.count > 0 {
+            if bodyText.count > 0 {
                 self.bodyLabel.text = bodyText
                 self.bodyLabel.textColor = notificationManager.notificationsBodyTextColor
                 self.bodyLabel.font = notificationManager.notificationsBodyFont
@@ -134,7 +134,7 @@ public class LNRNotificationView: UIView, UIGestureRecognizerDelegate {
         self.titleLabel.frame = CGRect(x: textLabelsXPosition, y: topPadding, width: notificationWidth - textLabelsXPosition - padding, height: CGFloat(0.0))
         self.titleLabel.sizeToFit()
         
-        if self.notification.body != nil && (self.notification.body!).characters.count > 0 {
+        if self.notification.body != nil && (self.notification.body!).count > 0 {
             self.bodyLabel.frame = CGRect(x: textLabelsXPosition, y: self.titleLabel.frame.origin.y + self.titleLabel.frame.size.height + kBodyLabelTopPadding, width: notificationWidth - padding - textLabelsXPosition, height: 0.0)
             self.bodyLabel.sizeToFit()
             height = self.bodyLabel.frame.origin.y + self.bodyLabel.frame.size.height


### PR DESCRIPTION
Xcode 9.1 is throwing 2 warnings of the type: `'characters' is deprecated: Please use String or Substring directly`

when including the pod directly as `pod 'LNRSimpleNotifications'` in the podfile.

This should solve the issue