### PR TITLE
Add @objc annotation to public methods

### DIFF
--- a/Source/LNRNotification.swift
+++ b/Source/LNRNotification.swift
@@ -12,27 +12,27 @@ public class LNRNotification: NSObject {
     /**
      *  The title of this notification
      */
-    public var title: String
+    @objc public var title: String
     
     /**
      *  The body of this notification
      */
-    public var body: String?
+    @objc public var body: String?
     
     /**
      *  The duration of the displayed notification. If it is 0.0 duration will default to the default notification display time
      */
-    public var duration: TimeInterval
+    @objc public var duration: TimeInterval
     
     /**
      *  An optional callback to be triggered whan a notification is tapped in addition to dismissing the notification.
      */
-    public var onTap: LNRNotificationOperationCompletionBlock?
+    @objc public var onTap: LNRNotificationOperationCompletionBlock?
     
     /**
      *  An optional callback to be triggered whan a notification times out without being tapped.
      */
-    public var onTimeout: LNRNotificationOperationCompletionBlock?
+    @objc public var onTimeout: LNRNotificationOperationCompletionBlock?
     
     /** Initializer for a LNRNotification. this library.
      *  @param title The title of the notification view
@@ -41,7 +41,7 @@ public class LNRNotification: NSObject {
      *  @param onTap The block that should be executed when the user taps on the notification
      *  @param onTimeout A block that should be executed when the notification times out. If the notification duration is set to endless (-1) this block will never be called.
      */
-    public init(title: String, body: String?, duration: TimeInterval = LNRNotificationDuration.default.rawValue, onTap: LNRNotificationOperationCompletionBlock? = nil, onTimeout: LNRNotificationOperationCompletionBlock? = nil) {
+    @objc public init(title: String, body: String?, duration: TimeInterval = LNRNotificationDuration.default.rawValue, onTap: LNRNotificationOperationCompletionBlock? = nil, onTimeout: LNRNotificationOperationCompletionBlock? = nil) {
         self.title = title
         self.body = body
         self.duration = duration

--- a/Source/LNRNotificationManager.swift
+++ b/Source/LNRNotificationManager.swift
@@ -35,7 +35,7 @@ public class LNRNotificationManager: NSObject {
      *  @param body The text that is displayed underneath the title
      *  @param onTap The block that should be executed when the user taps on the notification
      */
-    public func showNotification(notification: LNRNotification) {
+    @objc public func showNotification(notification: LNRNotification) {
         DispatchQueue.main.async {
             if self.isNotificationActive {
                 let _ = self.dismissActiveNotification(completion: { () -> Void in
@@ -52,7 +52,7 @@ public class LNRNotificationManager: NSObject {
      *  @param completion The block that should be executed when the notification finishes dismissing
      *  @return true if notification dismissal was triggered, false if no notification was currently displayed.
      */
-    public func dismissActiveNotification(completion: LNRNotificationOperationCompletionBlock?) -> Bool {
+    @objc public func dismissActiveNotification(completion: LNRNotificationOperationCompletionBlock?) -> Bool {
         
         if isNotificationActive {
             return self.dismissNotificationView(notificationView: self.activeNotification!, dismissAnimationCompletion: { () -> Void in
@@ -70,7 +70,7 @@ public class LNRNotificationManager: NSObject {
      *  @param dismissAnimationCompletion The block that should be executed when the notification finishes dismissing
      *  @return true if notification dismissal was triggered, false if notification was not currently displayed.
      */
-    public func dismissNotificationView(notificationView: LNRNotificationView, dismissAnimationCompletion:LNRNotificationOperationCompletionBlock?) -> Bool {
+    @objc public func dismissNotificationView(notificationView: LNRNotificationView, dismissAnimationCompletion:LNRNotificationOperationCompletionBlock?) -> Bool {
         
         if notificationView.isDisplayed {
             var offScreenPoint: CGPoint
@@ -112,51 +112,51 @@ public class LNRNotificationManager: NSObject {
      *
      *  @return true if a notification is being displayed
      */
-    public var isNotificationActive: Bool {
+    @objc public var isNotificationActive: Bool {
         return (self.activeNotification != nil)
     }
     
     /**
      *  The active notification, if there is one. nil if no notification is currently active.
      */
-    public var activeNotification: LNRNotificationView?
+    @objc public var activeNotification: LNRNotificationView?
     
     // MARK: Notification Styling
     
     /**
     *  Use to set the background color of notifications.
     */
-    public var notificationsBackgroundColor: UIColor = UIColor.white
+    @objc public var notificationsBackgroundColor: UIColor = UIColor.white
     
     /**
      *  Use to set the title text color of notifications
      */
-    public var notificationsTitleTextColor: UIColor = UIColor.black
+    @objc public var notificationsTitleTextColor: UIColor = UIColor.black
     
     /**
      *  Use to set the body text color of notifications.
      */
-    public var notificationsBodyTextColor: UIColor = UIColor.black
+    @objc public var notificationsBodyTextColor: UIColor = UIColor.black
     
     /**
      *  Use to set the title font of notifications.
      */
-    public var notificationsTitleFont: UIFont = UIFont.boldSystemFont(ofSize: 14.0)
+    @objc public var notificationsTitleFont: UIFont = UIFont.boldSystemFont(ofSize: 14.0)
     
     /**
      *  Use to set the body font of notifications.
      */
-    public var notificationsBodyFont: UIFont = UIFont.systemFont(ofSize: 12.0)
+    @objc public var notificationsBodyFont: UIFont = UIFont.systemFont(ofSize: 12.0)
     
     /**
      *  Use to set the bottom/top seperator color.
      */
-    public var notificationsSeperatorColor: UIColor = UIColor.clear
+    @objc public var notificationsSeperatorColor: UIColor = UIColor.clear
     
     /**
      *  Use to set the icon displayed with notifications.
      */
-    public var notificationsIcon: UIImage?
+    @objc public var notificationsIcon: UIImage?
     
     /**
      *  Use to set the position of notifications on screen.
@@ -169,7 +169,6 @@ public class LNRNotificationManager: NSObject {
     public var notificationSound: SystemSoundID?
     
     // MARK: Internal
-    
     private func displayNotificationView(notificationView: LNRNotificationView) {
         
         self.activeNotification = notificationView

--- a/Source/LNRNotificationQueue.swift
+++ b/Source/LNRNotificationQueue.swift
@@ -16,14 +16,14 @@ public class LNRNotificationQueue: NSObject {
      * 
      *  @param notificationManager The LNRNotificationManager that will be used to display queued messages. You should not trigger notifications from this Notification Manager anywhere else in your app.
      */
-    public init(notificationManager: LNRNotificationManager) {
+    @objc public init(notificationManager: LNRNotificationManager) {
         self.notificationManager = notificationManager
     }
     
     /**
      *  Queues a notification to be displayed.
      */
-    public func queueNotification(notification: LNRNotification) {
+    @objc public func queueNotification(notification: LNRNotification) {
         if notificationManager.isNotificationActive {
             notificationQueue.append(notification)
         } else {

--- a/Source/LNRNotificationView.swift
+++ b/Source/LNRNotificationView.swift
@@ -18,19 +18,19 @@ public class LNRNotificationView: UIView, UIGestureRecognizerDelegate {
     /**
      *  Set to YES by the Notification manager while the notification view is onscreen
      */
-    public var isDisplayed: Bool = false
+    @objc public var isDisplayed: Bool = false
     
     /**
      *  The LNRNotification this LNRNotificationView represents
      */
-    public var notification: LNRNotification
+    @objc public var notification: LNRNotification
     
     /** Inits the notification view. Do not call this from outside this library.
      *  
      *  @param notification The LNRNotification object this LRNNotificationView represents
      *  @param dismissingEnabled Should this notification be dismissed when the user taps/swipes it?
      */
-    init(notification: LNRNotification, icon: UIImage?, notificationManager: LNRNotificationManager) {
+    @objc init(notification: LNRNotification, icon: UIImage?, notificationManager: LNRNotificationManager) {
         
         self.notification = notification
         self.notificationManager = notificationManager
@@ -97,7 +97,7 @@ public class LNRNotificationView: UIView, UIGestureRecognizerDelegate {
     /**
      * Required initializer 'init(coder:)' must be implemented by subclasses of UIView
      */
-    required public init?(coder decoder: NSCoder) {
+    @objc required public init?(coder decoder: NSCoder) {
         assertionFailure("Cannot initialize LNRNotificationView with init:decoder")
         self.notification = LNRNotification(title: "", body: nil, onTap: nil, onTimeout: nil)
         super.init(coder: decoder)
@@ -108,7 +108,7 @@ public class LNRNotificationView: UIView, UIGestureRecognizerDelegate {
      *  @param completion A block called after the completion of the dismiss animation. This block is only called if the notification was displayed on screen at the time dismissWithCompletion: was called.
      *  @return true if notification was displayed at the time dismissWithCompletion: was called, false if notification was not displayed.
      */
-    public func dismissWithCompletion(_ completion: LNRNotificationOperationCompletionBlock?) -> Bool {
+    @objc public func dismissWithCompletion(_ completion: LNRNotificationOperationCompletionBlock?) -> Bool {
         return notificationManager.dismissNotificationView(notificationView: self, dismissAnimationCompletion: completion)
     }
     


### PR DESCRIPTION
This was the default behaviour in Swift 3 - the compiler inferred all these annotations automatically.
Now in Swift 4, the compiler does not automatically infer these anymore and its necessary to explicitly add these `@objc` annotations to methods that should be available in ObjC.